### PR TITLE
keep PC matrix 2-dimensional even if only one PC

### DIFF
--- a/R/Examine_Region_Methylation.R
+++ b/R/Examine_Region_Methylation.R
@@ -161,7 +161,7 @@ getPCs <- function(meth, mod = matrix(1, nrow = ncol(meth), ncol = 1),
         meth_t <- t(meth)
         meth_t_centered <- scale(meth_t, center = TRUE, scale = FALSE)
         ss <- svd(meth_t_centered)
-        PCs <- ss$u[, 1:n.pc]
+        PCs <- ss$u[, 1:n.pc, drop=FALSE]
         dimnames(PCs) <- list(dimnames(meth_t)[[1]], paste0("PC_", 1:n.pc))
         if(save){
                 if(verbose){


### PR DESCRIPTION
The prior code will fail when only one PC is selected because by default R will drop the singleton dimension and then the result is not an array type, so `dimnames(PCs)` generates an error. Adding `drop = FALSE` to the subset keeps the single PC as a column matrix, so everything will work.